### PR TITLE
Support ParameteryEntry as an argument

### DIFF
--- a/src/yamcs/pymdb/xtce.py
+++ b/src/yamcs/pymdb/xtce.py
@@ -178,12 +178,17 @@ class XTCE12Generator:
                 if not set_el:
                     set_el = ET.SubElement(parent, "ArgumentTypeSet")
 
+                # Handle ParameterEntrys not having a default
+                default = None
+                if hasattr(argument, 'default'):
+                    default = argument.default
+
                 # Make an argument type unique to each command
                 self.add_argument_type(
                     set_el,
                     system,
                     name=f"{command.name}__{argument.name}",
-                    default=argument.default,
+                    default=default,
                     data_type=argument,
                 )
 


### PR DESCRIPTION
When attempting to use a ParameterEntry as an argument for a command, you will get this error:
```
  File ".../yamcs/pymdb/xtce.py", line 186, in add_argument_type_set
    default=default,
NameError: name 'default' is not defined
```
This is because while arguments have 'default', ParameterEntry does not.
While it does instead have a 'initial_value' field, but it would be better to not assign a ParameterEntry's initial_value as the default argument since that would cause that argument to be hidden inside the default dropdown menu when trying to Send a Command in YAMCS.

This would help with not having to define the same field that appears in telemetry containers and commands twice -- once as a parameter and again as an argument.